### PR TITLE
Feat #24: Tema MUI customizado azul + verde + DESIGN.md

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,75 @@
+# DESIGN.md — Mentoria GS
+
+## Marca
+
+- **Nome:** Mentoria GS / Prof. Jean Ribeiro
+- **Segmento:** Educação / Preparatório para Vestibulares
+- **Foco:** Vestibulares do Paraná (UEM, UEL, UEPG, UNICENTRO, UFPR) + ENEM
+
+## Paleta de Cores
+
+### Primária — Azul (Confiança, Educação)
+
+| Token | Cor | Hex |
+|-------|-----|-----|
+| `primary.main` | Azul escuro | `#1565C0` |
+| `primary.light` | Azul médio | `#1E88E5` |
+| `primary.dark` | Azul profundo | `#0D47A1` |
+
+### Secundária — Verde (Crescimento, Conhecimento)
+
+| Token | Cor | Hex |
+|-------|-----|-----|
+| `secondary.main` | Verde escuro | `#2E7D32` |
+| `secondary.light` | Verde médio | `#43A047` |
+| `secondary.dark` | Verde profundo | `#1B5E20` |
+
+### Neutros
+
+| Token | Uso | Hex |
+|-------|-----|-----|
+| `background.default` | Fundo da página | `#FAFBFC` |
+| `background.paper` | Cards/superfícies | `#FFFFFF` |
+| `text.primary` | Títulos/texto principal | `#1A1A2E` |
+| `text.secondary` | Subtítulos/descrições | `#546E7A` |
+
+## Tipografia
+
+- **Fonte principal:** Inter (Google Fonts)
+- **Pesos:** 400 (regular), 500, 600 (semibold), 700 (bold), 800 (extrabold)
+- **Fallback:** Roboto, Helvetica, Arial, sans-serif
+
+### Escala
+
+| Nível | Peso | Uso |
+|-------|------|-----|
+| `h3` | 700 | Títulos de seção |
+| `h4` | 700 | Subtítulos |
+| `h5` | 600 | Cards, módulos |
+| `h6` | 600 | Navegação |
+| `button` | 600 | Botões (sem uppercase) |
+
+## Shape
+
+- **Border radius padrão:** 12px
+- **Botões:** 10px, padding 10px 24px
+- **Cards:** 16px
+
+## Componentes
+
+### Botões
+- `textTransform: none` (sem uppercase)
+- `fontWeight: 600`
+- `borderRadius: 10px`
+- Padding generoso: 10px 24px
+
+### Cards
+- `borderRadius: 16px`
+- Elevação consistente via MUI
+
+## Princípios de Design
+
+1. **Clareza > Decoração** — Interface limpa, foco no conteúdo educacional
+2. **Cores com propósito** — Azul para navegação/ação, verde para sucesso/confirmação
+3. **Hierarquia clara** — Títulos em negrito, espaçamento generoso
+4. **Acessibilidade** — Contraste suficiente, alvos de toque ≥ 44px

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,10 +1,13 @@
 <!doctype html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Mentoria para vestibulares</title>
+    <title>Mentoria GS — Simulados para Vestibulares</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -40,10 +40,63 @@ import VisualizarSimulado from "./pages/public/Simulados/VisualizarSimulado";
 const theme = createTheme({
   palette: {
     primary: {
-      main: "#1976d2",
+      main: "#1565C0",
+      light: "#1E88E5",
+      dark: "#0D47A1",
+      contrastText: "#FFFFFF",
     },
     secondary: {
-      main: "#dc004e",
+      main: "#2E7D32",
+      light: "#43A047",
+      dark: "#1B5E20",
+      contrastText: "#FFFFFF",
+    },
+    background: {
+      default: "#FAFBFC",
+      paper: "#FFFFFF",
+    },
+    text: {
+      primary: "#1A1A2E",
+      secondary: "#546E7A",
+    },
+  },
+  typography: {
+    fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+    h3: {
+      fontWeight: 700,
+    },
+    h4: {
+      fontWeight: 700,
+    },
+    h5: {
+      fontWeight: 600,
+    },
+    h6: {
+      fontWeight: 600,
+    },
+    button: {
+      textTransform: "none",
+      fontWeight: 600,
+    },
+  },
+  shape: {
+    borderRadius: 12,
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 10,
+          padding: "10px 24px",
+        },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 16,
+        },
+      },
     },
   },
 });

--- a/apps/web/src/styles/style.css
+++ b/apps/web/src/styles/style.css
@@ -1,9 +1,14 @@
 /* Standard Theme Variables */
 :root {
-  --primary-color: #1976d2;
-  --secondary-color: #dc004e;
-  --bg-color: #ffffff;
-  --text-color: #213547;
+  --primary-color: #1565C0;
+  --primary-light: #1E88E5;
+  --primary-dark: #0D47A1;
+  --secondary-color: #2E7D32;
+  --secondary-light: #43A047;
+  --secondary-dark: #1B5E20;
+  --bg-color: #FAFBFC;
+  --text-color: #1A1A2E;
+  --text-secondary: #546E7A;
   --card-bg: rgba(255, 255, 255, 0.9);
   --border-color: rgba(0, 0, 0, 0.12);
   --input-bg: #f5f5f5;


### PR DESCRIPTION
## O que mudou

**Problema:** Tema MUI usava cores padrão (#1976d2 blue + #dc004e pink) sem identidade visual.

**Mudanças:**

### 🎨 Tema MUI customizado
- **Primary:** Azul `#1565C0` — confiança, educação
- **Secondary:** Verde `#2E7D32` — crescimento, conhecimento
- Background `#FAFBFC`, text `#1A1A2E` (neutros refinados)
- Tipografia: Inter carregada via Google Fonts
- Botões sem uppercase, border radius 10px
- Cards com border radius 16px

### 📄 DESIGN.md criado
Documenta paleta, tipografia, componentes e princípios de design.

### 🔧 CSS variables atualizadas
`style.css` reflete as novas cores da marca.

### 🌐 index.html
- lang pt-BR
- Título: "Mentoria GS — Simulados para Vestibulares"
- Inter importada via Google Fonts

## Arquivos alterados
- `apps/web/src/App.tsx` — tema customizado
- `apps/web/src/styles/style.css` — vars atualizadas
- `apps/web/index.html` — lang, título, fonte Inter
- `DESIGN.md` — novo (sistema de design documentado)

Closes #24