### PR TITLE
Fix #26: Hero gradient azul + verde alinhado com a marca

### DIFF
--- a/apps/web/src/components/public/Hero.tsx
+++ b/apps/web/src/components/public/Hero.tsx
@@ -22,7 +22,7 @@ export function Hero({
 }: HeroProps) {
   return (
     <Box
-      sx={{
+      sx={(theme) => ({
         position: "relative",
         height: {
           xs: "250px",
@@ -31,7 +31,7 @@ export function Hero({
         },
         backgroundImage: imagemFundo
           ? `url(${imagemFundo})`
-          : "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
+          : `linear-gradient(135deg, ${theme.palette.primary.dark} 0%, ${theme.palette.primary.main} 50%, ${theme.palette.secondary.main} 100%)`,
         backgroundSize: "cover",
         backgroundPosition: "center",
         display: "flex",
@@ -44,10 +44,10 @@ export function Hero({
           left: 0,
           right: 0,
           bottom: 0,
-          backgroundColor: "rgba(0, 0, 0, 0.5)",
+          backgroundColor: "rgba(0, 0, 0, 0.4)",
           zIndex: 1,
         },
-      }}
+      })}
     >
       <Container maxWidth="lg" sx={{ position: "relative", zIndex: 2 }}>
         <Typography


### PR DESCRIPTION
## O que mudou

**Problema:** Hero usava gradiente roxo (#667eea → #764ba2) que não combinava com o tema azul+verde da marca.

**Antes:**
```
linear-gradient(135deg, #667eea 0%, #764ba2 100%)
```

**Depois:** (usa as cores do tema dinamicamente)
```
linear-gradient(135deg, primary.dark → primary.main → secondary.main)
```
Resultado visual: **Azul escuro → Azul → Verde**

### Mudanças
- Gradiente agora usa `theme.palette` — se o tema mudar, o Hero acompanha
- Overlay escuro reduzido de 0.5 → 0.4 (gradiente mais vivo transparece)

Closes #26