### PR TITLE
Fix #27: Remove gradient text e glassmorphism como padrão

### DIFF
--- a/apps/web/src/styles/style.css
+++ b/apps/web/src/styles/style.css
@@ -9,10 +9,8 @@
   --bg-color: #FAFBFC;
   --text-color: #1A1A2E;
   --text-secondary: #546E7A;
-  --card-bg: rgba(255, 255, 255, 0.9);
   --border-color: rgba(0, 0, 0, 0.12);
   --input-bg: #f5f5f5;
-  --glass-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.1);
 }
 
 html,
@@ -42,13 +40,16 @@ body {
 
 /* Premium UI Classes */
 .glass-container {
-  background: var(--card-bg);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
+  background: var(--bg-color);
   border: 1px solid var(--border-color);
-  border-radius: 24px;
-  box-shadow: var(--glass-shadow);
+  border-radius: 16px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
   padding: 2rem;
+  transition: box-shadow 0.2s ease;
+}
+
+.glass-container:hover {
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
 }
 
 .simulado-header {
@@ -60,10 +61,7 @@ body {
   font-size: 2.5rem;
   font-weight: 800;
   margin-bottom: 1rem;
-  background: linear-gradient(to right, var(--primary-color), var(--secondary-color));
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: var(--primary-color);
 }
 
 .form-label {


### PR DESCRIPTION
## O que mudou

**Problema:** Dois anti-patterns de design no `style.css`:
1. **Gradient text** em `.simulado-title` (background-clip: text)
2. **Glassmorphism** como padrão em `.glass-container` (backdrop-filter blur)

### Mudanças

**Gradient text removido** ✅
- Antes: `background: linear-gradient(...)` com `background-clip: text`
- Depois: Cor sólida `var(--primary-color)` com `font-weight: 800`
- Destaque via peso da fonte, não via gradiente (boas práticas)

**Glassmorphism substituído** ✅
- Antes: `backdrop-filter: blur(12px)` + `--glass-shadow` roxo
- Depois: Fundo sólido `--bg-color`, sombra sutil `0 4px 24px`, border-radius 16px
- Hover suave com elevação da sombra
- Sem blur, sem glass, sem elementos decorativos desnecessários

**CSS variables limpas** 🧹
- Remove `--card-bg` e `--glass-shadow` (não usadas)

Closes #27