### PR TITLE
Feat #28 #30: ConfirmDialog + Skeleton + replace window.confirm()

### DIFF
--- a/apps/web/src/components/ui/ConfirmDialog.tsx
+++ b/apps/web/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,62 @@
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+} from "@mui/material";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  confirmColor?: "primary" | "error" | "warning" | "success";
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmText = "Confirmar",
+  cancelText = "Cancelar",
+  confirmColor = "error",
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onClose={onCancel}
+      maxWidth="xs"
+      fullWidth
+      PaperProps={{
+        sx: { borderRadius: 3, p: 1 },
+      }}
+    >
+      <DialogTitle sx={{ fontWeight: 700 }}>{title}</DialogTitle>
+      <DialogContent>
+        <DialogContentText color="text.secondary">
+          {message}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onCancel} variant="outlined" color="inherit">
+          {cancelText}
+        </Button>
+        <Button
+          onClick={onConfirm}
+          variant="contained"
+          color={confirmColor}
+          autoFocus
+        >
+          {confirmText}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/ui/Table.tsx
+++ b/apps/web/src/components/ui/Table.tsx
@@ -7,8 +7,8 @@ import {
   TableRow,
   Paper,
   TablePagination,
-  // Box,
   Typography,
+  Skeleton,
 } from "@mui/material";
 import { useState } from "react";
 
@@ -51,7 +51,38 @@ export function Table<T extends { _id?: string; id?: string }>({
   };
 
   if (loading) {
-    return <Typography sx={{ p: 2 }}>Carregando dados...</Typography>;
+    return (
+      <Paper sx={{ width: "100%", overflow: "hidden" }}>
+        <TableContainer>
+          <MuiTable>
+            <TableHead>
+              <TableRow>
+                {columns.map((column) => (
+                  <TableCell key={String(column.id)}>
+                    {column.label}
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {Array.from({ length: 5 }).map((_, i) => (
+                <TableRow key={i}>
+                  {columns.map((column) => (
+                    <TableCell key={String(column.id)}>
+                      <Skeleton
+                        variant="text"
+                        width={column.id === "actions" ? 60 : "80%"}
+                        height={24}
+                      />
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </MuiTable>
+        </TableContainer>
+      </Paper>
+    );
   }
 
   if (rows.length === 0) {

--- a/apps/web/src/pages/admin/Alunos/ListaAlunos.tsx
+++ b/apps/web/src/pages/admin/Alunos/ListaAlunos.tsx
@@ -11,12 +11,14 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import { useToast } from "../../../store/useToast";
 import { useAuth } from "../../../hooks/useAuth";
 import { EditAlunoDialog } from "./EditAlunoDialog";
+import { ConfirmDialog } from "../../../components/ui/ConfirmDialog";
 
 export function ListaAlunos() {
   const [alunos, setAlunos] = useState<IAluno[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedAluno, setSelectedAluno] = useState<IAluno | null>(null);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<IAluno | null>(null);
   const navigate = useNavigate();
   const { showToast } = useToast();
   const { user } = useAuth();
@@ -53,14 +55,16 @@ export function ListaAlunos() {
     }
   };
 
-  const handleDelete = async (id: string) => {
-    if (!window.confirm("Tem certeza que deseja excluir este aluno?")) return;
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget?._id) return;
     try {
-      await AlunosService.delete(id);
+      await AlunosService.delete(deleteTarget._id);
       showToast("Aluno excluído com sucesso!", "success");
       loadAlunos();
     } catch {
       showToast("Erro ao excluir aluno.", "error");
+    } finally {
+      setDeleteTarget(null);
     }
   };
 
@@ -78,11 +82,10 @@ export function ListaAlunos() {
     },
     { id: "name", label: "Nome", minWidth: 170 },
     { id: "email", label: "Email", minWidth: 170 },
-    // Only show "Escola" column if user is Admin
     ...(user?.role === "admin"
       ? [
           {
-            id: "escolaId",
+            id: "escolaId" as const,
             label: "Escola",
             minWidth: 170,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -106,7 +109,7 @@ export function ListaAlunos() {
           </IconButton>
           <IconButton
             size="small"
-            onClick={() => handleDelete(row._id!)}
+            onClick={() => setDeleteTarget(row)}
             color="error"
           >
             <DeleteIcon fontSize="small" />
@@ -146,6 +149,16 @@ export function ListaAlunos() {
         onClose={() => setIsEditDialogOpen(false)}
         onSave={handleSave}
         aluno={selectedAluno}
+      />
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        title="Excluir aluno"
+        message={`Tem certeza que deseja excluir "${deleteTarget?.name}"? Esta ação não pode ser desfeita.`}
+        confirmText="Excluir"
+        confirmColor="error"
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
       />
     </Box>
   );

--- a/apps/web/src/pages/admin/BancoQuestoes/ConfigurarDrive.tsx
+++ b/apps/web/src/pages/admin/BancoQuestoes/ConfigurarDrive.tsx
@@ -25,6 +25,7 @@ import SaveIcon from "@mui/icons-material/Save";
 import SyncIcon from "@mui/icons-material/Sync";
 import DeleteIcon from "@mui/icons-material/Delete";
 import FolderIcon from "@mui/icons-material/Folder";
+import { ConfirmDialog } from "../../../components/ui/ConfirmDialog";
 
 export function ConfigurarDrive() {
   const { showToast } = useToast();
@@ -37,6 +38,7 @@ export function ConfigurarDrive() {
     folderName: "",
     folderUrl: "",
   });
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
 
   useEffect(() => {
     loadData();
@@ -96,15 +98,16 @@ export function ConfigurarDrive() {
     }
   };
 
-  const handleDelete = async (codigo: string) => {
-    if (!window.confirm("Deseja realmente remover esta configuração?")) return;
-
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
     try {
-      await DriveConfigService.delete(codigo);
+      await DriveConfigService.delete(deleteTarget);
       showToast("Configuração removida", "success");
       loadData();
     } catch (error) {
       showToast(`Erro ao remover: ${error}`);
+    } finally {
+      setDeleteTarget(null);
     }
   };
 
@@ -232,7 +235,7 @@ export function ConfigurarDrive() {
                   <IconButton
                     size="small"
                     color="error"
-                    onClick={() => handleDelete(config.vestibularCodigo)}
+                    onClick={() => setDeleteTarget(config.vestibularCodigo)}
                     title="Remover"
                   >
                     <DeleteIcon />
@@ -251,6 +254,16 @@ export function ConfigurarDrive() {
           </Paper>
         )}
       </Stack>
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        title="Remover configuração"
+        message="Deseja realmente remover esta configuração? Os PDFs sincronizados não serão afetados."
+        confirmText="Remover"
+        confirmColor="error"
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </Box>
   );
 }

--- a/apps/web/src/pages/admin/BancoQuestoes/ListaPdfs.tsx
+++ b/apps/web/src/pages/admin/BancoQuestoes/ListaPdfs.tsx
@@ -9,7 +9,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  //   Button,
   Chip,
   IconButton,
   MenuItem,
@@ -30,17 +29,20 @@ import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import DescriptionIcon from "@mui/icons-material/Description";
 import RefreshIcon from "@mui/icons-material/Refresh";
+import { ConfirmDialog } from "../../../components/ui/ConfirmDialog";
 
 export function ListaPdfs() {
   const { showToast } = useToast();
-  // const [loading, setLoading] = useState(false); // Removido em favor de extractingIds
   const [pdfs, setPdfs] = useState<IPdfSource[]>([]);
   const [vestibulares, setVestibulares] = useState<IVestibular[]>([]);
   const [filterVestibular, setFilterVestibular] = useState("");
   const [filterStatus, setFilterStatus] = useState("");
 
-  // Estado para controlar quais PDFs estão sendo extraídos individualmente
   const [extractingIds, setExtractingIds] = useState<string[]>([]);
+  const [extractTarget, setExtractTarget] = useState<{
+    id: string;
+    name: string;
+  } | null>(null);
 
   useEffect(() => {
     loadData();
@@ -59,11 +61,16 @@ export function ListaPdfs() {
     }
   };
 
-  const handleExtract = async (id: string, fileName: string) => {
-    if (!window.confirm(`Extrair questões de ${fileName}?`)) return;
+  const handleExtractClick = (id: string, fileName: string) => {
+    setExtractTarget({ id, name: fileName });
+  };
+
+  const handleExtractConfirm = async () => {
+    if (!extractTarget) return;
+    const { id } = extractTarget;
+    setExtractTarget(null);
 
     try {
-      // Adiciona ID ao array de extração
       setExtractingIds((prev) => [...prev, id]);
 
       const result = await PdfExtractionService.extractFromPdf(id);
@@ -239,7 +246,7 @@ export function ListaPdfs() {
                           <IconButton
                             size="small"
                             color="primary"
-                            onClick={() => handleExtract(pdf._id, pdf.fileName)}
+                            onClick={() => handleExtractClick(pdf._id, pdf.fileName)}
                             title="Extrair Questões"
                           >
                             <PlayArrowIcon fontSize="small" />
@@ -249,7 +256,7 @@ export function ListaPdfs() {
                           <IconButton
                             size="small"
                             color="secondary"
-                            onClick={() => handleExtract(pdf._id, pdf.fileName)}
+                            onClick={() => handleExtractClick(pdf._id, pdf.fileName)}
                             title="Refazer Extração"
                           >
                             <RefreshIcon fontSize="small" />
@@ -272,6 +279,16 @@ export function ListaPdfs() {
           </Typography>
         </Paper>
       )}
+
+      <ConfirmDialog
+        open={!!extractTarget}
+        title="Extrair questões"
+        message={`Deseja extrair questões de "${extractTarget?.name}"? A extração pode levar alguns segundos.`}
+        confirmText="Extrair"
+        confirmColor="primary"
+        onConfirm={handleExtractConfirm}
+        onCancel={() => setExtractTarget(null)}
+      />
     </Box>
   );
 }

--- a/apps/web/src/pages/admin/Escolas/ListaEscolas.tsx
+++ b/apps/web/src/pages/admin/Escolas/ListaEscolas.tsx
@@ -10,12 +10,14 @@ import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { useToast } from "../../../store/useToast";
 import { EditEscolaDialog } from "./EditEscolaDialog";
+import { ConfirmDialog } from "../../../components/ui/ConfirmDialog";
 
 export function ListaEscolas() {
   const [escolas, setEscolas] = useState<IEscola[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedEscola, setSelectedEscola] = useState<IEscola | null>(null);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<IEscola | null>(null);
   const navigate = useNavigate();
   const { showToast } = useToast();
 
@@ -51,14 +53,16 @@ export function ListaEscolas() {
     }
   };
 
-  const handleDelete = async (id: string) => {
-    if (!window.confirm("Tem certeza que deseja excluir esta escola?")) return;
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget?._id) return;
     try {
-      await EscolasService.delete(id);
+      await EscolasService.delete(deleteTarget._id);
       showToast("Escola excluída com sucesso!", "success");
       loadEscolas();
     } catch {
       showToast("Erro ao excluir escola.", "error");
+    } finally {
+      setDeleteTarget(null);
     }
   };
 
@@ -97,7 +101,7 @@ export function ListaEscolas() {
           </IconButton>
           <IconButton
             size="small"
-            onClick={() => handleDelete(row._id!)}
+            onClick={() => setDeleteTarget(row)}
             color="error"
           >
             <DeleteIcon fontSize="small" />
@@ -132,6 +136,16 @@ export function ListaEscolas() {
         onClose={() => setIsEditDialogOpen(false)}
         onSave={handleSave}
         escola={selectedEscola}
+      />
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        title="Excluir escola"
+        message={`Tem certeza que deseja excluir "${deleteTarget?.nomeEscola || deleteTarget?.name}"? Esta ação não pode ser desfeita.`}
+        confirmText="Excluir"
+        confirmColor="error"
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
       />
     </Box>
   );

--- a/apps/web/src/pages/admin/Vestibulares/GerenciarVestibulares.tsx
+++ b/apps/web/src/pages/admin/Vestibulares/GerenciarVestibulares.tsx
@@ -14,6 +14,7 @@ import {
   IconButton,
   Chip,
   Stack,
+  Skeleton,
 } from "@mui/material";
 import {
   VestibularesService,
@@ -25,10 +26,16 @@ import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import SyncIcon from "@mui/icons-material/Sync";
+import { ConfirmDialog } from "../../../components/ui/ConfirmDialog";
 
 export function GerenciarVestibulares() {
   const [vestibulares, setVestibulares] = useState<IVestibular[]>([]);
   const [loading, setLoading] = useState(true);
+  const [deleteTarget, setDeleteTarget] = useState<{
+    codigo: string;
+    nome: string;
+  } | null>(null);
+  const [syncOpen, setSyncOpen] = useState(false);
   const navigate = useNavigate();
   const { showToast } = useToast();
 
@@ -47,28 +54,23 @@ export function GerenciarVestibulares() {
     loadVestibulares();
   }, [loadVestibulares]);
 
-  const handleDelete = async (codigo: string, nome: string) => {
-    if (!window.confirm(`Deseja realmente excluir ${nome}?`)) return;
-
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
     try {
-      await VestibularesService.delete(codigo);
+      await VestibularesService.delete(deleteTarget.codigo);
       showToast("Vestibular removido com sucesso", "success");
       loadVestibulares();
     } catch (error) {
       showToast(`Erro ao remover vestibular: ${error}`);
+    } finally {
+      setDeleteTarget(null);
     }
   };
 
-  const handleSync = async () => {
-    if (
-      !window.confirm(
-        "Deseja sincronizar vestibulares? Isso pode levar alguns segundos."
-      )
-    )
-      return;
-
+  const handleSyncConfirm = async () => {
+    setSyncOpen(false);
+    setLoading(true);
     try {
-      setLoading(true);
       const result = await VestibularesService.sync();
       showToast(
         `Sincronização concluída! Criados: ${result.created}, Atualizados: ${result.updated}, Ignorados: ${result.skipped}`,
@@ -83,7 +85,43 @@ export function GerenciarVestibulares() {
   };
 
   if (loading) {
-    return <Typography>Carregando...</Typography>;
+    return (
+      <Box sx={{ p: 3 }}>
+        <Stack direction="row" justifyContent="space-between" sx={{ mb: 3 }}>
+          <Skeleton variant="text" width={300} height={40} />
+          <Stack direction="row" spacing={2}>
+            <Skeleton variant="rounded" width={140} height={40} />
+            <Skeleton variant="rounded" width={160} height={40} />
+          </Stack>
+        </Stack>
+        <Paper>
+          <TableContainer>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  {["Código", "Nome", "Nome Completo", "Cidade/Estado", "Status", "Ações"].map(
+                    (h) => (
+                      <TableCell key={h}>{h}</TableCell>
+                    )
+                  )}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <TableRow key={i}>
+                    {Array.from({ length: 6 }).map((_, j) => (
+                      <TableCell key={j}>
+                        <Skeleton variant="text" width={j === 5 ? 60 : "70%"} height={24} />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Paper>
+      </Box>
+    );
   }
 
   return (
@@ -99,7 +137,7 @@ export function GerenciarVestibulares() {
           <Button
             variant="outlined"
             startIcon={<SyncIcon />}
-            onClick={handleSync}
+            onClick={() => setSyncOpen(true)}
             disabled={loading}
           >
             Sincronizar
@@ -170,7 +208,10 @@ export function GerenciarVestibulares() {
                     size="small"
                     color="error"
                     onClick={() =>
-                      handleDelete(vestibular.codigo, vestibular.nome)
+                      setDeleteTarget({
+                        codigo: vestibular.codigo,
+                        nome: vestibular.nome,
+                      })
                     }
                     title="Excluir"
                   >
@@ -190,6 +231,26 @@ export function GerenciarVestibulares() {
           </Typography>
         </Box>
       )}
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        title="Excluir vestibular"
+        message={`Deseja realmente excluir "${deleteTarget?.nome}"? Esta ação não pode ser desfeita.`}
+        confirmText="Excluir"
+        confirmColor="error"
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
+
+      <ConfirmDialog
+        open={syncOpen}
+        title="Sincronizar vestibulares"
+        message="Deseja sincronizar vestibulares? Isso pode levar alguns segundos."
+        confirmText="Sincronizar"
+        confirmColor="primary"
+        onConfirm={handleSyncConfirm}
+        onCancel={() => setSyncOpen(false)}
+      />
     </Box>
   );
 }


### PR DESCRIPTION
## O que mudou

### #28 — ConfirmDialog (substitui window.confirm())
**Componente novo:** `components/ui/ConfirmDialog.tsx` — Dialog MUI reutilizável

**6 `window.confirm()` substituídos:**
- `ListaEscolas.tsx` — excluir escola
- `ListaAlunos.tsx` — excluir aluno
- `GerenciarVestibulares.tsx` — excluir vestibular + sincronizar
- `ListaPdfs.tsx` — extrair questões de PDF
- `ConfigurarDrive.tsx` — remover configuração do Drive

### #30 — Skeleton loading
**Table.tsx:** Loading state agora mostra skeleton rows (5 linhas com Skeleton) ao invés de "Carregando dados..."
**GerenciarVestibulares.tsx:** Loading state com Skeleton no header + tabela

## Arquivos alterados
- `components/ui/ConfirmDialog.tsx` — **novo**
- `components/ui/Table.tsx` — Skeleton loading
- `pages/admin/Escolas/ListaEscolas.tsx` — ConfirmDialog
- `pages/admin/Alunos/ListaAlunos.tsx` — ConfirmDialog
- `pages/admin/Vestibulares/GerenciarVestibulares.tsx` — ConfirmDialog + Skeleton
- `pages/admin/BancoQuestoes/ListaPdfs.tsx` — ConfirmDialog
- `pages/admin/BancoQuestoes/ConfigurarDrive.tsx` — ConfirmDialog

Closes #28
Closes #30