### PR TITLE
Fix #36: Navbar breakpoint mobile de lg para md

### DIFF
--- a/apps/web/src/components/public/Navbar.tsx
+++ b/apps/web/src/components/public/Navbar.tsx
@@ -25,7 +25,7 @@ import { useNavigate } from "react-router-dom";
 export function Navbar() {
   const navigate = useNavigate();
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("lg"));
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
   const [mobileOpen, setMobileOpen] = useState(false);
   const [vestibularesAnchor, setVestibularesAnchor] =
     useState<null | HTMLElement>(null);


### PR DESCRIPTION
## O que mudou

**Problema:** Navbar usava `down(\"lg\")` (1200px) para mostrar menu hamburger, deixando tablets com navegacao apertada.

**Mudanca:** `down(\"lg\")` -> `down(\"md\")` (900px)

- Abaixo de 900px: menu hamburger (mobile)
- Acima de 900px: navegacao completa (desktop/tablet grande)

Closes #36